### PR TITLE
Add thumbnails to main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,12 +148,22 @@
       list-style: none;
       padding: 0;
     }
-    .resource-links li {
-      margin: 5px 0;
-    }
-    .resource-links a {
-      color: blue;
-    }
+      .resource-links li {
+        margin: 10px 0;
+        display: flex;
+        align-items: center;
+      }
+      .resource-links img {
+        width: 120px;
+        height: auto;
+        margin-right: 10px;
+        border-radius: 5px;
+      }
+      .resource-links a {
+        color: blue;
+        display: flex;
+        align-items: center;
+      }
     /* Styles for quiz feedback */
     .quiz label[data-result="right"] {
         color: green;
@@ -273,11 +283,36 @@ summary { font-weight: bold; }
       <h2>Projects</h2>
       <div class="resource-links">
         <ul>
-          <li><a href="https://stevencowell.github.io/Yr-9-Breadboard/" target="_blank">Breadboard</a></li>
-          <li><a href="https://stevencowell.github.io/Yr-9-Clock/" target="_blank">Clock</a></li>
-          <li><a href="https://stevencowell.github.io/Yr-10-Mirror/" target="_blank">Mirror</a></li>
-          <li><a href="https://stevencowell.github.io/desk-tidy/" target="_blank">Desk Tidy</a></li>
-          <li><a href="https://stevencowell.github.io/Bedside-Table/" target="_blank">Bedside Table</a></li>
+          <li>
+            <a href="https://stevencowell.github.io/Yr-9-Breadboard/" target="_blank">
+              <img src="Breadboard.png" alt="Breadboard project thumbnail" />
+              Breadboard
+            </a>
+          </li>
+          <li>
+            <a href="https://stevencowell.github.io/Yr-9-Clock/" target="_blank">
+              <img src="Clock.png" alt="Clock project thumbnail" />
+              Clock
+            </a>
+          </li>
+          <li>
+            <a href="https://stevencowell.github.io/Yr-10-Mirror/" target="_blank">
+              <img src="Mirror Picture.png" alt="Mirror project thumbnail" />
+              Mirror
+            </a>
+          </li>
+          <li>
+            <a href="https://stevencowell.github.io/desk-tidy/" target="_blank">
+              <img src="desk tidy picture (1).png" alt="Desk Tidy project thumbnail" />
+              Desk Tidy
+            </a>
+          </li>
+          <li>
+            <a href="https://stevencowell.github.io/Bedside-Table/" target="_blank">
+              <img src="table (1).png" alt="Bedside Table project thumbnail" />
+              Bedside Table
+            </a>
+          </li>
         </ul>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- display thumbnail images for each project on the index page
- add CSS to style the thumbnails

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684257568d988326ab50646a642f6589