### PR TITLE
Add Pen webpage card

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,6 +219,12 @@
           </div>
           <div class="project-title">Bedside Table</div>
         </a>
+        <a href="https://stevencowell.github.io/Pen-Website/" class="project-card" target="_blank">
+          <div class="thumb-container">
+            <img src="pen.jpg" alt="Pen project thumbnail" />
+          </div>
+          <div class="project-title">Pen</div>
+        </a>
         <a href="https://stevencowell.github.io/Construction-Supplementary-material/supplementary%20material/index.html" class="project-card" target="_blank">
           <div class="thumb-container">
             <img src="https://images.pexels.com/photos/159306/construction-site-build-construction-work-159306.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="Construction tools on a blueprint" />


### PR DESCRIPTION
## Summary
- add a tile on the main page linking to the Pen project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68846116b03483268315669db2356e26