### PR TITLE
Switch to box.png for Small Box card image

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
         </a>
         <a href="https://stevencowell.github.io/Small-Box/" class="project-card" target="_blank">
           <div class="thumb-container">
-            <img src="combined.png" alt="Small Box project thumbnail" />
+            <img src="box.png" alt="Small Box project thumbnail" />
           </div>
           <div class="project-title">Small Box</div>
         </a>


### PR DESCRIPTION
## Summary
- use `box.png` as the Small Box card thumbnail on the main page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884adbb8e5883269c88bdfa464a98d4