### PR TITLE
Swap manufacturing card thumbnail to metal_fabricator.jpg

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,7 +242,7 @@
         </a>
         <a href="https://stevencowell.github.io/Manufacturing/" class="project-card" target="_blank">
           <div class="thumb-container">
-            <img src="combined.png" alt="Manufacturing supplementary material thumbnail" />
+            <img src="metal_fabricator.jpg" alt="Manufacturing supplementary material thumbnail" />
           </div>
           <div class="project-title">Manufacturing Supplementary Material</div>
         </a>


### PR DESCRIPTION
### Motivation
- Replace the existing manufacturing thumbnail with the new metal fabricator photo to better represent the Manufacturing supplementary material.

### Description
- In `index.html` updated the manufacturing project card image source from `combined.png` to `metal_fabricator.jpg` (alt text left unchanged).

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright capture which rendered the updated page and saved `artifacts/manufacturing-card.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698722feb3bc8326a5278c583a3b8061)