### PR TITLE
Focus main page on mirror projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="description" content="Industrial Arts Timber Technology" />
+  <meta name="description" content="Mirror project resources and student examples" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Industrial Arts Timber Technology</title>
+  <title>Mirror Project Resources</title>
 
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet" />
 
@@ -110,6 +110,11 @@
       grid-template-columns: repeat(3, 1fr);
       gap: 1.5rem;
     }
+    .mirror-grid {
+      max-width: 760px;
+      margin: 0 auto;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
     .project-card {
       background-color: #fff;
       border-radius: 8px;
@@ -176,6 +181,9 @@
       .projects-section h2 {
         font-size: 1.75rem;
       }
+      .mirror-grid {
+        grid-template-columns: 1fr;
+      }
     }
   </style>
 </head>
@@ -183,39 +191,15 @@
   <header>
     <a href="https://drive.google.com/drive/folders/1zI9Ha1fC5tsBIwEN2eLSVaLzcrmjzQFS?usp=drive_link" id="results-link">Results</a>
     <a href="Busy%20Worksheets.pdf" id="worksheets-link" target="_blank">Busy Worksheets</a>
-    <h1>Industrial Arts Timber Technology</h1>
-    <p>Explore our student projects in woodworking and design</p>
+    <h1>Mirror Project Resources</h1>
+    <p>Explore focused mirror project resources and student examples</p>
   </header>
 
   <main>
     <section class="projects-section">
-      <h2>Projects</h2>
+      <h2>Mirror Projects</h2>
 
-      <div class="projects-grid">
-        <a href="https://stevencowell.github.io/desk-tidy/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="desk tidy picture (1).png" alt="Desk Tidy project thumbnail" />
-          </div>
-          <div class="project-title">Desk Tidy</div>
-        </a>
-        <a href="https://stevencowell.github.io/Yr-9-Breadboard/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="Breadboard.png" alt="Breadboard project thumbnail" />
-          </div>
-          <div class="project-title">Breadboard</div>
-        </a>
-        <a href="https://stevencowell.github.io/Yr-9-Clock/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="Clock.png" alt="Clock project thumbnail" />
-          </div>
-          <div class="project-title">Clock</div>
-        </a>
-        <a href="https://stevencowell.github.io/Carry-all/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="carryall.png" alt="Carry-All project thumbnail" />
-          </div>
-          <div class="project-title">Carry-All</div>
-        </a>
+      <div class="projects-grid mirror-grid">
         <a href="https://stevencowell.github.io/Yr-10-Mirror/" class="project-card" target="_blank">
           <div class="thumb-container">
             <img src="Mirror Picture.png" alt="Mirror project thumbnail" />
@@ -228,66 +212,12 @@
           </div>
           <div class="project-title">New Mirror</div>
         </a>
-        <a href="https://stevencowell.github.io/Bedside-Table/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="table (1).png" alt="Bedside Table project thumbnail" />
-          </div>
-          <div class="project-title">Bedside Table</div>
-        </a>
-        <a href="https://stevencowell.github.io/Pen-Website/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="pen.jpg" alt="Pen project thumbnail" />
-          </div>
-          <div class="project-title">Pen</div>
-        </a>
-        <a href="https://stevencowell.github.io/Construction-Supplementary-material/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="https://images.pexels.com/photos/159306/construction-site-build-construction-work-159306.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1" alt="Construction tools on a blueprint" />
-          </div>
-          <div class="project-title">Construction Supplementary Material</div>
-        </a>
-        <a href="https://stevencowell.github.io/Manufacturing/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="metal_fabricator.jpg" alt="Manufacturing supplementary material thumbnail" />
-          </div>
-          <div class="project-title">Manufacturing Supplementary Material</div>
-        </a>
-        <a href="https://stevencowell.github.io/Small-Box/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="box.png" alt="Small Box project thumbnail" />
-          </div>
-          <div class="project-title">Small Box</div>
-        </a>
-        <a href="https://stevencowell.github.io/Yr-8-Metal-Technology/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="metalwork.jpg" alt="Yr 8 Metal Technology project thumbnail" />
-          </div>
-          <div class="project-title">Yr 8 Metal Technology</div>
-        </a>
-        <a href="https://stevencowell.github.io/Yr-9-Metal/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="metal tools.png" alt="Metal tools project thumbnail" />
-          </div>
-          <div class="project-title">Yr 9 Metal</div>
-        </a>
-        <a href="https://stevencowell.github.io/Engineering-Website/index.html" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="Gear+Train+Pic.jpeg" alt="Engineering website gear and train thumbnail" />
-          </div>
-          <div class="project-title">Engineering Website</div>
-        </a>
-        <a href="https://stevencowell.github.io/matrix/" class="project-card" target="_blank">
-          <div class="thumb-container">
-            <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyMDAgMTIwJz4KICA8cmVjdCB3aWR0aD0nMjAwJyBoZWlnaHQ9JzEyMCcgcng9JzEyJyBmaWxsPScjMjE2OWQxJy8+CiAgPHJlY3QgeD0nMTQnIHk9JzIwJyB3aWR0aD0nMTcyJyBoZWlnaHQ9JzgwJyByeD0nOCcgZmlsbD0nd2hpdGUnIGZpbGwtb3BhY2l0eT0nMC4wOCcgc3Ryb2tlPScjZmZmZmZmJyBzdHJva2Utb3BhY2l0eT0nMC4zNScgc3Ryb2tlLXdpZHRoPScyJy8+CiAgPGcgZm9udC1mYW1pbHk9J1JvYm90bywgQXJpYWwsIHNhbnMtc2VyaWYnIGZpbGw9JyNmZmZmZmYnPgogICAgPHRleHQgeD0nNTAlJyB5PSc0OCUnIGZvbnQtc2l6ZT0nMTgnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk1hdHJpeDwvdGV4dD4KICAgIDx0ZXh0IHg9JzUwJScgeT0nNjglJyBmb250LXNpemU9JzE0JyB0ZXh0LWFuY2hvcj0nbWlkZGxlJz5Db250cm9sIENlbnRlcjwvdGV4dD4KICA8L2c+Cjwvc3ZnPg==" alt="Matrix Control Center interface illustration" />
-          </div>
-          <div class="project-title">Matrix Control Center</div>
-        </a>
       </div>
     </section>
   </main>
 
   <footer>
-    &copy; 2025 Industrial Arts Timber Technology | All Rights Reserved
+    &copy; 2025 Mirror Project Resources | All Rights Reserved
   </footer>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The site should stop referencing the broader Engineering website and instead present a focused landing page for Mirror project resources and student examples.

### Description
- Update page metadata and browser title to mirror-focused copy by changing the meta description and `<title>`.
- Replace the header copy with a mirror-specific heading and subtext and rename the projects section to “Mirror Projects”.
- Replace the projects grid contents to include only the Mirror and New Mirror project cards and remove the Engineering Website and other non-mirror cards.
- Add `.mirror-grid` CSS to center the two-card layout on desktop and stack cards on small screens, and update the footer branding to “Mirror Project Resources.”

### Testing
- `python3` HTML parser check succeeded and parsed `index.html` without error.
- `git diff --check` ran with no whitespace or diff-check errors reported.
- `rg -n "Engineering|Engineering-Website|Industrial Arts" index.html` returned no matches, confirming references were removed.
- Headless browser / screenshot test could not run because `selenium`/browser binaries were not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a389f8204d88326bc9da1fda3593bbc)