### PR TITLE
Restore main project landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="description" content="Mirror project resources and student examples" />
+  <meta name="description" content="Industrial Arts Timber Technology project resources" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Mirror Project Resources</title>
+  <title>Industrial Arts Timber Technology</title>
 
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet" />
 
@@ -107,13 +107,8 @@
        ------------------------------------------------------------ */
     .projects-grid {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
       gap: 1.5rem;
-    }
-    .mirror-grid {
-      max-width: 760px;
-      margin: 0 auto;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .project-card {
       background-color: #fff;
@@ -181,9 +176,6 @@
       .projects-section h2 {
         font-size: 1.75rem;
       }
-      .mirror-grid {
-        grid-template-columns: 1fr;
-      }
     }
   </style>
 </head>
@@ -191,33 +183,70 @@
   <header>
     <a href="https://drive.google.com/drive/folders/1zI9Ha1fC5tsBIwEN2eLSVaLzcrmjzQFS?usp=drive_link" id="results-link">Results</a>
     <a href="Busy%20Worksheets.pdf" id="worksheets-link" target="_blank">Busy Worksheets</a>
-    <h1>Mirror Project Resources</h1>
-    <p>Explore focused mirror project resources and student examples</p>
+    <h1>Industrial Arts Timber Technology</h1>
+    <p>Explore our student projects in woodworking and design</p>
   </header>
 
   <main>
     <section class="projects-section">
-      <h2>Mirror Projects</h2>
+      <h2>Projects</h2>
 
-      <div class="projects-grid mirror-grid">
-        <a href="https://stevencowell.github.io/Yr-10-Mirror/" class="project-card" target="_blank">
+      <div class="projects-grid">
+        <!-- Desk Tidy Project Card -->
+        <a href="https://stevencowell.github.io/desk-tidy/" class="project-card" target="_blank">
+          <div class="thumb-container">
+            <img src="desk tidy picture (1).png" alt="Desk Tidy project thumbnail" />
+          </div>
+          <div class="project-title">Desk Tidy</div>
+        </a>
+        <!-- Breadboard Project Card -->
+        <a href="https://stevencowell.github.io/Yr-9-Breadboard/" class="project-card" target="_blank">
+          <div class="thumb-container">
+            <img src="Breadboard.png" alt="Breadboard project thumbnail" />
+          </div>
+          <div class="project-title">Breadboard</div>
+        </a>
+        <!-- Clock Project Card -->
+        <a href="https://stevencowell.github.io/Yr-9-Clock/" class="project-card" target="_blank">
+          <div class="thumb-container">
+            <img src="Clock.png" alt="Clock project thumbnail" />
+          </div>
+          <div class="project-title">Clock</div>
+        </a>
+        <!-- Carry-All Project Card -->
+        <a href="https://stevencowell.github.io/Carry-all/" class="project-card" target="_blank">
+          <div class="thumb-container">
+            <img src="carryall.png" alt="Carry-All project thumbnail" />
+          </div>
+          <div class="project-title">Carry-All</div>
+        </a>
+        <!-- Mirror Project Card -->
+        <a href="https://stevencowell.github.io/Yr-10-Mirror/Yr-10-Mirror-main/" class="project-card" target="_blank">
           <div class="thumb-container">
             <img src="Mirror Picture.png" alt="Mirror project thumbnail" />
           </div>
           <div class="project-title">Mirror</div>
         </a>
+        <!-- New Mirror Project Card -->
         <a href="https://stevencowell.github.io/New-Mirror-Website/" class="project-card" target="_blank">
           <div class="thumb-container">
             <img src="new-mirror.svg" alt="New Mirror project thumbnail" />
           </div>
           <div class="project-title">New Mirror</div>
         </a>
+        <!-- Bedside Table Project Card -->
+        <a href="https://stevencowell.github.io/Bedside-Table/" class="project-card" target="_blank">
+          <div class="thumb-container">
+            <img src="table (1).png" alt="Bedside Table project thumbnail" />
+          </div>
+          <div class="project-title">Bedside Table</div>
+        </a>
       </div>
     </section>
   </main>
 
   <footer>
-    &copy; 2025 Mirror Project Resources | All Rights Reserved
+    &copy; 2025 Industrial Arts Timber Technology | All Rights Reserved
   </footer>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The site had been narrowed to a mirror-only landing page; the intent of this change is to restore the original Industrial Arts Timber Technology main landing page that exposes the full set of student project links. 
- Make the page descriptive and discoverable by updating the page title and meta description to reflect the broader project collection. 
- Ensure the project grid is responsive so all project cards remain accessible on different screen sizes. 

### Description
- Updated `index.html` meta description and `<title>` to `Industrial Arts Timber Technology` and adjusted the header `<h1>` and intro paragraph to match. 
- Replaced the mirror-only card layout with the full project grid and added project cards for `Desk Tidy`, `Breadboard`, `Clock`, `Carry-All`, `Mirror`, `New Mirror`, and `Bedside Table` (each linking to the corresponding external site). 
- Changed the grid CSS to use `grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));` and removed the `.mirror-grid` special-case rules to restore a general responsive layout. 
- Updated the footer copy to `Industrial Arts Timber Technology` and preserved the header links for `Results` and `Busy Worksheets`. 

### Testing
- Ran an HTML parse check with `python3` using `html.parser` which parsed the updated `index.html` successfully. 
- Ran `git diff --check` which reported no whitespace/diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dbfe957648326b10b585d643ce97c)