### PR TITLE
Move TAS hero copy into dark panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,11 +71,17 @@
     .hero {
       min-height: 650px; display: grid; align-items: end; color: white;
       background:
-        linear-gradient(90deg, rgba(7, 29, 22, .91) 0%, rgba(7, 29, 22, .78) 34%, rgba(7, 29, 22, .25) 68%, rgba(7, 29, 22, .12) 100%),
+        linear-gradient(90deg, rgba(7, 29, 22, .97) 0%, rgba(7, 29, 22, .94) 34%, rgba(7, 29, 22, .80) 46%, rgba(7, 29, 22, .24) 70%, rgba(7, 29, 22, .08) 100%),
         linear-gradient(0deg, rgba(7, 29, 22, .76), transparent 48%),
         url("assets/tas-faculty-hero-v1.webp") center / cover no-repeat;
     }
-    .hero-content { max-width: 690px; padding: 160px 0 80px; }
+    .hero-content {
+      max-width: 620px;
+      width: min(620px, calc(100% - 40px));
+      margin-left: max(20px, calc((100vw - 1500px) / 2));
+      margin-right: 0;
+      padding: 160px 0 80px;
+    }
     .eyebrow {
       display: inline-flex; align-items: center; gap: 9px; margin: 0 0 18px;
       color: #f0d49f; font-size: .78rem; font-weight: 800; letter-spacing: .13em; text-transform: uppercase;
@@ -182,9 +188,13 @@
         background-position: 62% center;
         background-image:
           linear-gradient(0deg, rgba(7,29,22,.95) 0%, rgba(7,29,22,.7) 62%, rgba(7,29,22,.25) 100%),
-          url("assets/industrial-arts-hero.webp");
+          url("assets/tas-faculty-hero-v1.webp");
       }
-      .hero-content { padding: 170px 0 52px; }
+      .hero-content {
+        width: min(100% - 28px, 1180px);
+        margin-inline: auto;
+        padding: 170px 0 52px;
+      }
       h1 { font-size: clamp(3.1rem, 17vw, 4.7rem); }
       .hero-actions { align-items: stretch; flex-direction: column; }
       .button { width: 100%; }


### PR DESCRIPTION
Moves the desktop TAS hero content to the quiet dark left panel, narrows its measure, and strengthens the left-to-right overlay so the copy no longer obscures the faculty objects. Preserves centred mobile spacing and corrects the mobile hero to use the new TAS faculty banner. Verified against the exact draft at desktop width with the navigation remaining on one row.